### PR TITLE
Auto-populate the skill levels with a script

### DIFF
--- a/data/levels.json
+++ b/data/levels.json
@@ -2,31 +2,31 @@
     {
         "Level": 0,
         "Name": "None or N/A",
-        "Description": "    You do not possess this competency or are not required to apply or demonstrate this competency (this competency is not applicable\n    to your position)."
+        "Description": "You do not possess this competency or are not required to apply or demonstrate this competency (this competency is not applicable\nto your position)."
     },
     {
         "Level": 1,
         "Name": "Fundamental awareness (basic knowledge)",
-        "Description": "    You have a common knowledge or an understanding of basic techniques and concepts.\n    Focus is on learning and remembering."
+        "Description": "You have a common knowledge or an understanding of basic techniques and concepts.\nFocus is on learning and remembering."
     },
     {
         "Level": 2,
         "Name": "Novice (limited experience)",
-        "Description": "    You have the level of experience gained in a classroom or as a trainee on-the-job. You are expected to need help when performing this competency.\n    You understand and can discuss terminology, concepts, principles and issues related to this competency; you can use the full range of reference and resource materials in this skill.\n    Focus is on understanding and developing through on-the-job experience."
+        "Description": "You have the level of experience gained in a classroom or as a trainee on-the-job. You are expected to need help when performing this competency.\nYou understand and can discuss terminology, concepts, principles and issues related to this competency; you can use the full range of reference and resource materials in this skill.\nFocus is on understanding and developing through on-the-job experience."
     },
     {
         "Level": 3,
         "Name": "Intermediate prctitioner (practical application)",
-        "Description": "    You are able to successfully complete tasks in this competency as requested. Help from an advanced practitioner/expert may be required from time to time, but you can usually perform the competency independently.\n    You have applied this competency to situations occasionally while needing minimal guidance to perform tasks successfully.\n    You understand and can discuss the application and implications of changes to processes and policies in this area.\n    Focus is on applying well-known algorithms, paradigms and solutions to the job at hand and enhancing knowledge or skill."
+        "Description": "You are able to successfully complete tasks in this competency as requested. Help from an advanced practitioner/expert may be required from time to time, but you can usually perform the competency independently.\nYou have applied this competency to situations occasionally while needing minimal guidance to perform tasks successfully.\nYou understand and can discuss the application and implications of changes to processes and policies in this area.\nFocus is on applying well-known algorithms, paradigms and solutions to the job at hand and enhancing knowledge or skill."
     },
     {
         "Level": 4,
         "Name": "Advanced practitioner (applied theory)",
-        "Description": "    You can perform the actions associated with this skill without assistance. You are certainly recognized within your immediate group/organisation as \"a person to ask\" when difficult questions arise regarding this skill.\n    You have consistently provided practical/relevant ideas and perspectives on process or practice improvements which may easily be implemented.\n    You are capable of mentoring others in the application of this competency by translating complex nuances relating to this competency into easy to understand terms.\n    You participate in the development of reference and resource materials in this competency.\n    Focus is on designing or architecting new solutions - analysing, evaluating and creating/synthesis."
+        "Description": "You can perform the actions associated with this skill without assistance. You are certainly recognized within your immediate group/organisation as \"a person to ask\" when difficult questions arise regarding this skill.\nYou have consistently provided practical/relevant ideas and perspectives on process or practice improvements which may easily be implemented.\nYou are capable of mentoring others in the application of this competency by translating complex nuances relating to this competency into easy to understand terms.\nYou participate in the development of reference and resource materials in this competency.\nFocus is on designing or architecting new solutions - analysing, evaluating and creating/synthesis."
     },
     {
         "Level": 5,
         "Name": "Expert (recognised authority)",
-        "Description": "    You can provide guidance, troubleshoot and answer questions related to this area of expertise and the field where the skill is used.\n    You have demonstrated consistent excellence in applying this competency across multiple projects and/or organisations.\n    You are being recognised inside and outside your organisation as an authority in the area of the competency.\n    You create new applications for and/or lead the development of reference and resource materials for this competency.\n    You are able to explain the relevant process elements and issues in sufficient detail during discussions and presentations, to foster a greater understanding among internal and external colleagues and collaborators.\n    Focus is on strategy in the area of competency and shaping organisational and (inter)national policies."
+        "Description": "You can provide guidance, troubleshoot and answer questions related to this area of expertise and the field where the skill is used.\nYou have demonstrated consistent excellence in applying this competency across multiple projects and/or organisations.\nYou are being recognised inside and outside your organisation as an authority in the area of the competency.\nYou create new applications for and/or lead the development of reference and resource materials for this competency.\nYou are able to explain the relevant process elements and issues in sufficient detail during discussions and presentations, to foster a greater understanding among internal and external colleagues and collaborators.\nFocus is on strategy in the area of competency and shaping organisational and (inter)national policies."
     }
 ]

--- a/scripts/populate_db.py
+++ b/scripts/populate_db.py
@@ -35,7 +35,7 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 def populate_categories_and_skills(data: dict) -> None:  # type: ignore[type-arg]
-    """Populate the database with categories and skills from a file."""
+    """Populate the database with categories and skills from a dictionary."""
     from main.models import Category, Skill
 
     # Loop over categorys and add to db
@@ -83,6 +83,27 @@ def populate_categories_and_skills(data: dict) -> None:  # type: ignore[type-arg
                     skill.save()
 
 
+def populate_skill_levels(levels: list[dict]) -> None:  # type: ignore[type-arg]
+    """Populate the database with skill levels from a dictionary."""
+    from main.models import SkillLevel
+
+    # Loop over skill levels and add to db
+    for lvl in levels:
+        # Check if skill level already exists
+        level = lvl["Level"]
+        name = lvl["Name"]
+        description = lvl["Description"]
+        try:
+            skill_level = SkillLevel.objects.get(level=level)
+        except SkillLevel.DoesNotExist:
+            skill_level = SkillLevel.objects.create(
+                level=level,
+                name=name,
+                description=description,
+            )
+            skill_level.save()
+
+
 def main() -> None:
     """Main function to run the script."""
     import json
@@ -109,6 +130,13 @@ def main() -> None:
             skill_data = json.load(json_file)
 
     populate_categories_and_skills(skill_data)
+
+    # Load skill levels from file
+    levels = []
+    with open("data/levels.json") as json_file:
+        levels = json.load(json_file)
+
+    populate_skill_levels(levels)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_populate_db.py
+++ b/tests/scripts/test_populate_db.py
@@ -75,3 +75,36 @@ def test_populate_categories_and_skills() -> None:
     for skill in skills:
         skills_count += 1
     assert skills_count == 5
+
+
+@pytest.mark.django_db
+def test_populate_skill_levels() -> None:
+    """Test the populate_skill_levels function."""
+    from main.models import SkillLevel
+
+    data = [
+        {
+            "Level": 0,
+            "Name": "Name of Level 0",
+            "Description": "Description of Level 0",
+        },
+        {
+            "Level": 1,
+            "Name": "Name of Level 1",
+            "Description": "Description of Level 1",
+        },
+    ]
+
+    initial_skill_levels_count = 0
+    initial_skill_levels = SkillLevel.objects.all()
+    for skill in initial_skill_levels:
+        initial_skill_levels_count += 1
+    assert initial_skill_levels_count == 0
+
+    populate_db.populate_skill_levels(data)
+
+    skill_levels_count = 0
+    skill_levels = SkillLevel.objects.all()
+    for skill in skill_levels:
+        skill_levels_count += 1
+    assert skill_levels_count == 2


### PR DESCRIPTION
# Description

This adds to the existing script to add the framework. It uses the skill levels JSON file in the repo, but this might need to be removed later.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
