### PR TITLE
Reference the user model safely

### DIFF
--- a/main/forms.py
+++ b/main/forms.py
@@ -1,11 +1,17 @@
 """Forms module for the main app."""
 
+from typing import TYPE_CHECKING
+
+from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserCreationForm
 
-from .models import User
+if TYPE_CHECKING:
+    from .models import User as UserType
+
+User = get_user_model()
 
 
-class CustomUserCreationForm(UserCreationForm[User]):
+class CustomUserCreationForm(UserCreationForm["UserType"]):
     """Custom user creation form."""
 
     class Meta(UserCreationForm.Meta):  # type: ignore[name-defined]
@@ -14,7 +20,7 @@ class CustomUserCreationForm(UserCreationForm[User]):
         model = User
         fields = UserCreationForm.Meta.fields  # type: ignore[attr-defined]
 
-    def save(self, commit: bool = True) -> User:
+    def save(self, commit: bool = True) -> "UserType":
         """Save user."""
         # Save the provided password in hashed format
         user = super().save(commit=False)

--- a/main/forms.py
+++ b/main/forms.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserCreationForm
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .models import User as UserType
 
 User = get_user_model()

--- a/main/models.py
+++ b/main/models.py
@@ -1,5 +1,6 @@
 """Models module for the main app."""
 
+from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -77,6 +78,6 @@ class SkillLevel(models.Model):
 class UserSkill(models.Model):
     """Model for mapping users to skills and skill levels."""
 
-    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     skill = models.ForeignKey(Skill, on_delete=models.CASCADE)
     skill_level = models.ForeignKey(SkillLevel, on_delete=models.CASCADE)


### PR DESCRIPTION
# Description

A few small changes to stop referencing the User model directly and use the [recommended approach](https://docs.djangoproject.com/en/5.2/topics/auth/customizing/#referencing-the-user-model)

Fixes #402 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
