### PR TITLE
Use crispy-forms for bootstrap-style forms

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,8 @@ repos:
           - django-stubs-ext
           - django-bootstrap5
           - django-registration
+          - django-crispy-forms
+          - crispy-bootstrap5
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.45.0
     hooks:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,19 +20,27 @@ confusable-homoglyphs==3.3.1
     # via django-registration
 coverage[toml]==7.9.2
     # via pytest-cov
+crispy-bootstrap5==2025.6
+    # via direct_webapp (pyproject.toml)
 cssbeautifier==1.15.4
     # via djlint
 distlib==0.3.9
     # via virtualenv
 django==5.2.4
     # via
+    #   crispy-bootstrap5
     #   direct_webapp (pyproject.toml)
     #   django-bootstrap5
+    #   django-crispy-forms
     #   django-registration
     #   django-stubs
     #   django-stubs-ext
 django-bootstrap5==25.1
     # via direct_webapp (pyproject.toml)
+django-crispy-forms==2.4
+    # via
+    #   crispy-bootstrap5
+    #   direct_webapp (pyproject.toml)
 django-registration==5.2.1
     # via direct_webapp (pyproject.toml)
 django-stubs[compatible-mypy]==5.2.1

--- a/direct_webapp/settings/settings.py
+++ b/direct_webapp/settings/settings.py
@@ -123,12 +123,17 @@ INSTALLED_APPS = [
     *INSTALLED_APPS,
     "django_bootstrap5",
     "django_registration",
+    "crispy_forms",
+    "crispy_bootstrap5",
 ]
 MIDDLEWARE.insert(1, "whitenoise.middleware.WhiteNoiseMiddleware")
 STATIC_ROOT = BASE_DIR / "staticfiles"
 AUTH_USER_MODEL = "main.User"
 LOGIN_REDIRECT_URL = "/"
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap5"
+CRISPY_TEMPLATE_PACK = "bootstrap5"
 
 # Ensure the logs directory exists
 LOGS_DIR = BASE_DIR / "logs"

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -22,14 +22,22 @@ colorama==0.4.6
     #   mkdocs-material
 confusable-homoglyphs==3.3.1
     # via django-registration
+crispy-bootstrap5==2025.6
+    # via direct_webapp (pyproject.toml)
 django==5.2.4
     # via
+    #   crispy-bootstrap5
     #   direct_webapp (pyproject.toml)
     #   django-bootstrap5
+    #   django-crispy-forms
     #   django-registration
     #   django-stubs-ext
 django-bootstrap5==25.1
     # via direct_webapp (pyproject.toml)
+django-crispy-forms==2.4
+    # via
+    #   crispy-bootstrap5
+    #   direct_webapp (pyproject.toml)
 django-registration==5.2.1
     # via direct_webapp (pyproject.toml)
 django-stubs-ext==5.2.1

--- a/main/templates/django_registration/registration_form.html
+++ b/main/templates/django_registration/registration_form.html
@@ -1,10 +1,12 @@
 {% extends "main/base.html" %}
+{% load crispy_forms_tags %}
 {% block content %}
     <section class="container pt-5 mt-5">
         <h2>Register your account</h2>
         <form method="post">
-            {% csrf_token %} {{ form }}
-            <button type="submit">Sign up</button>
+            {% csrf_token %}
+            {{ form|crispy }}
+            <input type="submit" class="btn btn-primary" value="Sign up">
         </form>
     </section>
 {% endblock content %}

--- a/main/templates/registration/login.html
+++ b/main/templates/registration/login.html
@@ -1,11 +1,7 @@
 {% extends "main/base.html" %}
+{% load crispy_forms_tags %}
 {% block content %}
     <section class="container pt-5 mt-5">
-        {% if form.errors %}
-            <p>
-                Your username and password didn't match. Please try again or <a href="{% url 'create_user' %}">register</a> if you haven't already got an account.
-            </p>
-        {% endif %}
         {% if next %}
             {% if user.is_authenticated %}
                 <p>
@@ -16,21 +12,13 @@
                 <p>Please login to see this page.</p>
             {% endif %}
         {% endif %}
-        <form method="post" action="{% url 'login' %}">
+        <form method="post">
             {% csrf_token %}
-            <table>
-                <tr>
-                    <td>{{ form.username.label_tag }}</td>
-                    <td>{{ form.username }}</td>
-                </tr>
-                <tr>
-                    <td>{{ form.password.label_tag }}</td>
-                    <td>{{ form.password }}</td>
-                </tr>
-            </table>
-            <input type="submit" value="Login">
+            {{ form|crispy }}
+            <input type="submit" class="btn btn-secondary" value="Log in">
             <input type="hidden" name="next" value="{{ next }}">
         </form>
+        <p>&nbsp;</p>
         <p>
             <a href="{% url 'password_reset' %}">Lost password?</a>
         </p>

--- a/main/templates/registration/login.html
+++ b/main/templates/registration/login.html
@@ -15,7 +15,7 @@
         <form method="post">
             {% csrf_token %}
             {{ form|crispy }}
-            <input type="submit" class="btn btn-secondary" value="Log in">
+            <input type="submit" class="btn btn-primary" value="Log in">
             <input type="hidden" name="next" value="{{ next }}">
         </form>
         <p>&nbsp;</p>

--- a/main/templates/registration/password_change_form.html
+++ b/main/templates/registration/password_change_form.html
@@ -1,46 +1,12 @@
 {% extends "../main/base.html" %}
+{% load crispy_forms_tags %}
 {% block content %}
     <section class="container pt-5 mt-5">
-        {% if user.is_authenticated %}
-            <p>Please enter (and confirm) your new password.</p>
-            <form action="" method="post">
-                {% csrf_token %}
-                <table>
-                    <tr>
-                        <td>
-                            <label for="id_old_password">Old password:</label>
-                        </td>
-                        <td>{{ form.old_password }}</td>
-                    </tr>
-                    <tr>
-                        <td>{{ form.old_password.errors }}</td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <label for="id_new_password1">New password:</label>
-                        </td>
-                        <td>{{ form.new_password1 }}</td>
-                    </tr>
-                    <tr>
-                        <td>{{ form.new_password1.errors }}</td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <label for="id_new_password2">Confirm password:</label>
-                        </td>
-                        <td>{{ form.new_password2 }}</td>
-                    </tr>
-                    <tr>
-                        <td>{{ form.new_password2.errors }}</td>
-                    </tr>
-                    <tr>
-                        <td></td>
-                        <td>
-                            <input type="submit" value="Change my password">
-                        </td>
-                    </tr>
-                </table>
-            </form>
-        {% endif %}
+        <p>Please enter (and confirm) your new password.</p>
+        <form method="post">
+            {% csrf_token %}
+            {{ form|crispy }}
+            <input type="submit" class="btn btn-secondary" value="Change my password">
+        </form>
     </section>
 {% endblock content %}

--- a/main/templates/registration/password_change_form.html
+++ b/main/templates/registration/password_change_form.html
@@ -6,7 +6,7 @@
         <form method="post">
             {% csrf_token %}
             {{ form|crispy }}
-            <input type="submit" class="btn btn-secondary" value="Change my password">
+            <input type="submit" class="btn btn-primary" value="Change my password">
         </form>
     </section>
 {% endblock content %}

--- a/main/templates/registration/password_reset_confirm.html
+++ b/main/templates/registration/password_reset_confirm.html
@@ -7,7 +7,7 @@
             <form method="post">
                 {% csrf_token %}
                 {{ form|crispy }}
-                <input type="submit" class="btn btn-secondary" value="Change my password">
+                <input type="submit" class="btn btn-primary" value="Change my password">
             </form>
         {% else %}
             <h1>Password reset failed</h1>

--- a/main/templates/registration/password_reset_confirm.html
+++ b/main/templates/registration/password_reset_confirm.html
@@ -1,41 +1,18 @@
 {% extends "../main/base.html" %}
+{% load crispy_forms_tags %}
 {% block content %}
     <section class="container pt-5 mt-5">
         {% if validlink %}
             <p>Please enter (and confirm) your new password.</p>
-            <form action="" method="post">
+            <form method="post">
                 {% csrf_token %}
-                <table>
-                    <tr>
-                        <td>
-                            <label for="id_new_password1">New password:</label>
-                        </td>
-                        <td>{{ form.new_password1 }}</td>
-                    </tr>
-                    <tr>
-                        <td>{{ form.new_password1.errors }}</td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <label for="id_new_password2">Confirm password:</label>
-                        </td>
-                        <td>{{ form.new_password2 }}</td>
-                    </tr>
-                    <tr>
-                        <td>{{ form.new_password2.errors }}</td>
-                    </tr>
-                    <tr>
-                        <td></td>
-                        <td>
-                            <input type="submit" value="Change my password">
-                        </td>
-                    </tr>
-                </table>
+                {{ form|crispy }}
+                <input type="submit" class="btn btn-secondary" value="Change my password">
             </form>
         {% else %}
             <h1>Password reset failed</h1>
             <p>
-                The password reset link was invalid, possibly because it has already been used. Please request a new password reset.
+                The password reset link was invalid, possibly because it has already been used. Please <a href="{% url 'password_reset' %}">request a new password reset.</a>
             </p>
         {% endif %}
     </section>

--- a/main/templates/registration/password_reset_form.html
+++ b/main/templates/registration/password_reset_form.html
@@ -8,7 +8,7 @@
         <form method="post">
             {% csrf_token %}
             {{ form|crispy }}
-            <input type="submit" class="btn btn-secondary" value="Submit">
+            <input type="submit" class="btn btn-primary" value="Submit">
         </form>
     </br>
     <p>

--- a/main/templates/registration/password_reset_form.html
+++ b/main/templates/registration/password_reset_form.html
@@ -1,24 +1,18 @@
 {% extends "../main/base.html" %}
+{% load crispy_forms_tags %}
 {% block content %}
     <section class="container pt-5 mt-5">
-        <form action="" method="post">
+        <h2>Reset password</h2>
+        <p>Enter the email address you used to register.</p>
+        <p>We'll send you an email with your username and a link to reset your password.</p>
+        <form method="post">
             {% csrf_token %}
-            {% if form.email.errors %}{{ form.email.errors }}{% endif %}
-            <h2>Reset password</h2>
-            <p>Enter the email address you used to register.</p>
-            <p>We'll send you an email with your username and a link to reset your password.</p>
-            <table>
-                <tr>
-                    <td>{{ form.email.label_tag }}</td>
-                    <td>{{ form.email }}</td>
-                </tr>
-            </table>
-        </br>
-        <input type="submit" class="btn btn-secondary" value="Submit">
-    </form>
-</br>
-<p>
-    Back to <a href="{% url 'login' %}">login</a>.
-</p>
+            {{ form|crispy }}
+            <input type="submit" class="btn btn-secondary" value="Submit">
+        </form>
+    </br>
+    <p>
+        Back to <a href="{% url 'login' %}">login</a>.
+    </p>
 </section>
 {% endblock content %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "django-bootstrap5",
     "django-registration",
     "django-stubs-ext",
+    "django-crispy-forms",
+    "crispy-bootstrap5",
     "whitenoise",
     "sendgrid",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,14 +8,22 @@ asgiref==3.9.0
     # via django
 confusable-homoglyphs==3.3.1
     # via django-registration
+crispy-bootstrap5==2025.6
+    # via direct_webapp (pyproject.toml)
 django==5.2.4
     # via
+    #   crispy-bootstrap5
     #   direct_webapp (pyproject.toml)
     #   django-bootstrap5
+    #   django-crispy-forms
     #   django-registration
     #   django-stubs-ext
 django-bootstrap5==25.1
     # via direct_webapp (pyproject.toml)
+django-crispy-forms==2.4
+    # via
+    #   crispy-bootstrap5
+    #   direct_webapp (pyproject.toml)
 django-registration==5.2.1
     # via direct_webapp (pyproject.toml)
 django-stubs-ext==5.2.1


### PR DESCRIPTION
# Description

This PR uses `django-crispy-forms` and `crispy-bootstrap5` to easily apply Bootstrap styling to the existing user registration forms. There is more that can be done with these tools to customise forms in `forms.py`, but since there are no forms currently in there, this functionality hasn't been used. The main thing done in this PR is simplifying the existing templates and using the [`crispy` filter](https://django-crispy-forms.readthedocs.io/en/latest/filters.html) to get the bootstrap classes for the forms.

~Currently in draft as it is building off #395 which contains some extra registration forms compared with `main`~
We should wait until #395 is merged before we merge this.

Fixes #268 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
