### PR TITLE
fix #452 update google group link

### DIFF
--- a/main/templates/main/snippets/footer.html
+++ b/main/templates/main/snippets/footer.html
@@ -22,7 +22,7 @@
                         <i class="fa-brands fa-github"></i>
                     </a>
                     <a class="btn btn-icon btn-sm btn-secondary btn-mail rounded-circle"
-                       href="https://groups.google.com/g/rse-competencies-toolkit"
+                       href="https://groups.google.com/g/direct-framework"
                        aria-label="Mailing List">
                         <i class="fa-solid fa-envelope"></i>
                     </a>


### PR DESCRIPTION
# Description

This PR updates the link to the Google Group, which has changed from "https://groups.google.com/g/rse-competencies-toolkit" to "https://groups.google.com/g/direct-framework"

Fixes #452 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
