### PR TITLE
Auto load framework on docker container startup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,5 @@
 !direct_webapp
 !db
 db/*
+!scripts
+!data/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,7 @@ bower_components/
 main/static/assets/img2
 
 *storybook.log
+
+# Data
+data/
+!data/levels.json

--- a/README.md
+++ b/README.md
@@ -102,15 +102,29 @@ To get started:
 
 ### Installation with Docker
 
-The app can be run within a Docker container and a `docker-compose.yml` file is provided to make this easy for development.
+The app can be run within a Docker container and a `docker-compose.yml` file is provided
+to make this easy for development.
 
-Ensure you have [Docker](https://docs.docker.com/desktop/) installed and simply run:
+Requirements:
+
+1. You have a modern version of [Docker](https://docs.docker.com/desktop/) installed.
+2. You have a JSON version of the framework saved at `data/skills-competencies-framework.json`.
+
+To launch the server run:
 
 ```bash
 docker compose up
 ```
 
 The app will be available at <http://127.0.0.1:8000/> <!-- markdown-link-check-disable-line -->
+
+As above, create a superuser with
+
+```bash
+docker compose exec app python manage.py createsuperuser
+```
+
+The framework should be automatically loaded into the database.
 
 ## Updating Dependencies
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,5 +4,8 @@ set -e
 echo "Running migrations..."
 python manage.py migrate --noinput
 
+echo "Loading framework into Database..."
+python -m scripts.populate_db -j data/skills-competencies-framework.json
+
 echo "Starting Gunicorn..."
 exec "$@"

--- a/scripts/populate_db.py
+++ b/scripts/populate_db.py
@@ -115,7 +115,6 @@ def main() -> None:
     import os
     import sys
 
-    import yaml
     from django.core.wsgi import get_wsgi_application
 
     # Set up Django environment for standalone script
@@ -128,6 +127,8 @@ def main() -> None:
     # Load famework from file
     skill_data = {}
     if args.yaml_file:
+        import yaml
+
         with open(args.yaml_file) as yaml_file:
             skill_data = yaml.safe_load(yaml_file)
     elif args.json_file:


### PR DESCRIPTION
# Description

This PR adds a step to run the `populate_db` script when the docker container is started up. This requires a copy of the json version of the framework to be present in the `data/` folder.

@davehorsfall will including this file be possible in the Azure deployment? If not, I can get to work on #460

Fixes #459 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
