### PR TITLE
Update Gunicorn cmd to correctly reference the direct_webapp app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ USER nobody
 EXPOSE 8000
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["gunicorn", "rse_competencies_toolkit.wsgi:application", "--bind", "0.0.0.0:8000"]
+CMD ["gunicorn", "direct_webapp.wsgi:application", "--bind", "0.0.0.0:8000"]


### PR DESCRIPTION
# Description

This PR updates the Gunicorn command to reflect the new app name:
`CMD ["gunicorn", "direct_webapp.wsgi:application", "--bind", "0.0.0.0:8000"]`

Fixes #470

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
