### PR TITLE
Return mistakenly deleted tests

### DIFF
--- a/tests/main/test_registration_views.py
+++ b/tests/main/test_registration_views.py
@@ -7,7 +7,7 @@ from django.core import mail
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains
 
-from .view_utils import TemplateOkMixin
+from .view_utils import LoginRequiredMixin, TemplateOkMixin
 
 
 @pytest.fixture
@@ -139,6 +139,24 @@ class TestPasswordResetComplete(TemplateOkMixin):
 
     def _get_url(self):
         return reverse("password_reset_complete")
+
+
+class TestPasswordChangeForm(LoginRequiredMixin, TemplateOkMixin):
+    """Test suite for the password_change views."""
+
+    _template_name = "registration/password_change_form.html"
+
+    def _get_url(self):
+        return reverse("password_change")
+
+
+class TestPasswordChangeDone(LoginRequiredMixin, TemplateOkMixin):
+    """Test suite for the password_change_done views."""
+
+    _template_name = "registration/password_change_done.html"
+
+    def _get_url(self):
+        return reverse("password_change_done")
 
 
 class TestRegisterUser(TemplateOkMixin):


### PR DESCRIPTION
# Description

The tests for the password change views were mistakenly deleted. This reverts commit 4309cfb031f5da7e1891708edd825a4b6bae597c which deleted them.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
