### PR TITLE
Pre workshop content tweaks

### DIFF
--- a/main/templates/main/pages/competencies.html
+++ b/main/templates/main/pages/competencies.html
@@ -20,6 +20,14 @@
                 <li class="breadcrumb-item active" aria-current="page">Competencies</li>
             </ol>
         </nav>
+        <div class="row">
+            <div class="col-lg-9 col-xl-8 pe-lg-4 pe-xl-0">
+                <h1 class="pb-2 pb-lg-3">Competencies framework</h1>
+                <p class="fs-lg mb-5">
+                    This page outlines the Digital Research Competencies Framework. Skills and competencies are organised into a number of categories and sub-categories which you can explore using the links in the sidebar.
+                </p>
+            </div>
+        </div>
         <div class="row pt-sm-2 pt-lg-0">
             <!-- Sidebar (offcanvas on screens < 992px) -->
             <aside class="col-lg-3">

--- a/main/templates/main/pages/training.html
+++ b/main/templates/main/pages/training.html
@@ -19,11 +19,8 @@
         <div class="row">
             <div class="col-lg-9 col-xl-8 pe-lg-4 pe-xl-0">
                 <h1 class="pb-2 pb-lg-3">Training resources</h1>
-                <p class="fs-lg pt-2 pt-sm-3">
-                    Dolor laoreet fermentum lectus praesent aenean molestie mollis integer. Sem ullamcorper montes, lorem ullamcorper orci, pellentesque ipsum malesuada gravida. Donec imperdiet nulla suscipit in. Dignissim ornare ac lorem consectetur massa a. Pellentesque urna pharetra, quis maecenas. Sit dolor amet nulla aenean eu, ac. Nisl mi tempus, iaculis viverra vestibulum scelerisque imperdiet montes. Mauris massa elit pretium elementum eget tortor quis. Semper interdum lectus odio diam.
-                </p>
-                <p class="fs-lg mb-3">
-                    Ut pellentesque bibendum dignissim a molestie. Ultrices diam ut vel neque tincidunt eget. Sed ut quis sit semper nunc at etiam lacinia. Quam laoreet eget id sapien a pharetra, ornare diam dignissim. Lorem amet nisl, enim mi aenean mauris. Porta nisl a ultrices ut libero id. Gravida a mi neque, tristique justo, et pharetra. Laoreet nulla est nulla cras ac arcu sed mattis tristique. Morbi convallis suspendisse enim blandit massa. Cursus augue dui mattis morbi velit.
+                <p class="fs-lg mb-5">
+                    This section will be developed in future to provide resources for training and personal development pathways.
                 </p>
             </div>
             <aside class="col-lg-3 offset-xl-1">

--- a/main/templates/main/snippets/head.html
+++ b/main/templates/main/snippets/head.html
@@ -8,10 +8,10 @@
     {% endblock title %}
 </title>
 <meta name="description"
-      content="Around - Multipurpose Bootstrap HTML Template">
+      content="DIRECT: Digital Research Competencies Framework">
 <meta name="keywords"
-      content="bootstrap, business, corporate, coworking space, services, creative agency, dashboard, e-commerce, mobile app showcase, saas, multipurpose, product landing, shop, software, ui kit, web studio, landing, light and dark mode, html5, css3, javascript, gallery, slider, touch, creative">
-<meta name="author" content="Createx Studio">
+      content="skills, competencies, professional, development, research, software, career, community, training">
+<meta name="author" content="DIRECT project team">
 <!-- Webmanifest + Favicon / App icons -->
 <link rel="manifest" href="{% static 'manifest.json' %}">
 <link rel="icon"

--- a/main/templates/main/user_self_assess.html
+++ b/main/templates/main/user_self_assess.html
@@ -16,9 +16,9 @@
                     <a href="{% url 'index' %}">Home</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <a href="{% url 'privacy' %}">Framework</a>
+                    <a href="{% url 'account-overview' %}">Profile</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page">Competencies</li>
+                <li class="breadcrumb-item active" aria-current="page">Assess Skills</li>
             </ol>
         </nav>
         <div class="row pt-sm-2 pt-lg-0">

--- a/main/templates/main/user_skill_profile.html
+++ b/main/templates/main/user_skill_profile.html
@@ -17,9 +17,9 @@
                     <a href="{% url 'index' %}">Home</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <a href="{% url 'privacy' %}">Framework</a>
+                    <a href="{% url 'account-overview' %}">Profile</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page">Competencies</li>
+                <li class="breadcrumb-item active" aria-current="page">View Skills</li>
             </ol>
         </nav>
         <div class="row pt-sm-2 pt-lg-0">


### PR DESCRIPTION
# Description

Tidy up content ahead of RSECon25 workshop:

- Write a brief paragraph stating that content will be coming in future iterations for https://directframework.com/training/
- add an intro para similar to the skill levels page for https://directframework.com/competencies/, e.g. "This page outlines the Digital Research Competencies Framework vX.X.X"
- Update the breadcrumb trail on https://directframework.com/self-assess/ to "Home > Profile > Assess skills" (and similarly for skills wheel page)
- Remove reference to Around template in the description tag in the <head> (also updated keywords and author tags)

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
