### PR TITLE
Add json download button

### DIFF
--- a/main/templates/main/snippets/export_user_skill_profile.html
+++ b/main/templates/main/snippets/export_user_skill_profile.html
@@ -7,8 +7,8 @@ To use add a button with the class "export-skill-profile" to the page and includ
 
 -->
 <script>
-    const exportSkillProfileButton = document.querySelector('.export-skill-profile');
-    exportSkillProfileButton.addEventListener('click', function () {
+    const exportSkillProfileCsvButton = document.querySelector('.export-skill-profile-csv');
+    exportSkillProfileCsvButton.addEventListener('click', function () {
       // The skill levels and chart data are passed from the Django view
       // We assume we receive the same data as the skill wheel.
       const skillLevels = {{ skill_levels|safe }};
@@ -26,6 +26,31 @@ To use add a button with the class "export-skill-profile" to the page and includ
       const link = document.createElement("a");
       link.setAttribute("href", encodedUri);
       link.setAttribute("download", "skill_profile.csv");
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    });
+    const exportSkillProfileJSONButton = document.querySelector('.export-skill-profile-json');
+    exportSkillProfileJSONButton.addEventListener('click', function () {
+      // The skill levels and chart data are passed from the Django view
+      // We assume we receive the same data as the skill wheel.
+      const skillLevels = {{ skill_levels|safe }};
+      const charts = {{ chart_data|safe }};
+
+      const jsonData = charts.map(({user_data, user_id}) => {
+        return user_data.map(({category, skill, skill_level, subcategory}) => {
+          return {
+            category,
+            subcategory,
+            skill,
+            level: skill_level
+          };
+        });
+      }).flat();
+      const jsonContent = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(jsonData, null, 2));
+      const link = document.createElement("a");
+      link.setAttribute("href", encodedUri);
+      link.setAttribute("download", "skill_profile.json");
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);

--- a/main/templates/main/snippets/export_user_skill_profile.html
+++ b/main/templates/main/snippets/export_user_skill_profile.html
@@ -1,9 +1,9 @@
-<!-- This template implements an export button to export the current user's skill profile as a CSV file.
- It works on the skill profile page.
+<!-- This template implements an export button to export the current user's skill profile as a CSV or json file.
 
 
-To use add a button with the class "export-skill-profile" to the page and include the following script at the end of the page.
-"{ % include "main/snippets/export_user_skill_profile.html" %}"
+To use add a button with the class `export-skill-profile-csv` and `export-skill-profile-json`
+ to the page and include the following script at the end of the page.
+`{ % include "main/snippets/export_user_skill_profile.html" %}`
 
 -->
 <script>

--- a/main/templates/main/snippets/share_skill_profile_dropdown.html
+++ b/main/templates/main/snippets/share_skill_profile_dropdown.html
@@ -1,4 +1,9 @@
-<!-- Share dropdown -->
+<!-- Share dropdown
+
+This template implements a share dropdown menu for the skill profile page.
+It includes options to open a shareable link, copy the link, and export the skill profile as CSV or JSON.
+
+-->
 <div class="dropdown nav d-none d-sm-block order-lg-3  justify-content-end">
     <li class="nav-item d-flex align-items-center justify-content-end">
         <a class="nav-link dropdown-toggle justify-content-end"

--- a/main/templates/main/snippets/share_skill_profile_dropdown.html
+++ b/main/templates/main/snippets/share_skill_profile_dropdown.html
@@ -22,9 +22,12 @@
                 {% include "main/snippets/create_user_skill_profile_link.html" %}
             </li>
             <li>
-                <button class="dropdown-item export-skill-profile" href="#">Export as CSV</button>
-                {% include "main/snippets/export_user_skill_profile.html" %}
+                <button class="dropdown-item export-skill-profile-csv" href="#">Export as CSV</button>
             </li>
+            <li>
+                <button class="dropdown-item export-skill-profile-json" href="#">Export as JSON</button>
+            </li>
+            {% include "main/snippets/export_user_skill_profile.html" %}
         </ul>
     </li>
 </div>


### PR DESCRIPTION
# Description

Implements a json download link in addition to the csv download link added previously.

Also improved the share button docs

Fixes #742 
Fixes: #770 

## Type of change

- [x] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
